### PR TITLE
bug(deis-dev): fix chart name for deis-dev, fixes search

### DIFF
--- a/deis-dev/Chart.yaml
+++ b/deis-dev/Chart.yaml
@@ -1,9 +1,9 @@
-name: deis
+name: deis-dev
 home: https://github.com/deis/workflow
 version: v2-beta
 description: For testing only!
 maintainers:
-- Matt Boersma <mboersma@deis.com>
+- Deis Engineering <engineering@deis.com>
 details: |-
   WARNING: this chart is for testing only! Features may not work, the
   components are not HA, and there are likely to be bugs.


### PR DESCRIPTION
Allows you to `helm search deis-dev`!